### PR TITLE
Rediseña dashboard con Tailwind y heroicons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,45 +4,68 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Perfil de Actividad Bancaria</title>
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
+    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   </head>
-  <body>
-    <div class="container my-4" id="dashboard">
-      <h1 class="mb-4">Perfil de actividad</h1>
+  <body class="bg-gray-100">
+    <div id="dashboard" class="max-w-5xl mx-auto p-4 space-y-6">
+      <h1 class="text-2xl font-bold">Perfil de actividad</h1>
 
-      <!-- Totals and flow chart -->
-      <div class="row" id="totalsCards"></div>
-      <div class="my-4">
-        <canvas id="flowChart" height="120"></canvas>
-      </div>
+      <div id="topCards" class="grid grid-cols-2 md:grid-cols-4 gap-4"></div>
 
-      <!-- Heatmap for hourly distribution -->
-      <div class="my-4">
-        <h3>Distribución horaria (Heatmap)</h3>
-        <div
-          id="hourHeatmap"
-          class="d-flex flex-wrap"
-          style="width: 480px"
-        ></div>
-      </div>
-
-      <div class="row">
-        <div class="col-md-6">
-          <h3>Histograma horario</h3>
-          <canvas id="hourChart" height="200"></canvas>
+      <div class="grid md:grid-cols-2 gap-4">
+        <div>
+          <h3 class="text-lg font-semibold mb-2">Histograma horario</h3>
+          <canvas id="hourChart" class="bg-white p-2 rounded" height="200"></canvas>
         </div>
-        <div class="col-md-6">
-          <h3>% Outliers (Z≥3.5)</h3>
-          <canvas id="outlierGauge" height="200"></canvas>
+        <div>
+          <div class="flex items-center mb-2">
+            <h3 class="text-lg font-semibold">% Outliers (Z≥3.5)</h3>
+            <button
+              id="outlierInfo"
+              title="Porcentaje de montos atípicos (z≥3.5)"
+              class="ml-2 text-gray-500 hover:text-gray-700"
+            >
+              <svg
+                class="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"
+                />
+              </svg>
+            </button>
+          </div>
+          <canvas
+            id="outlierGauge"
+            class="bg-white p-2 rounded"
+            height="200"
+          ></canvas>
         </div>
       </div>
 
-      <!-- Other metric groups -->
-      <div class="row" id="otherCards"></div>
+      <div class="grid md:grid-cols-2 gap-4">
+        <div class="bg-white p-4 rounded shadow">
+          <h3 class="text-lg font-semibold mb-4">Métricas de montos</h3>
+          <canvas id="amountMetricsChart" height="200"></canvas>
+        </div>
+        <div>
+          <h3 class="text-lg font-semibold mb-2">Recencia</h3>
+          <canvas
+            id="recencyHist"
+            class="bg-white p-2 rounded"
+            height="200"
+          ></canvas>
+        </div>
+      </div>
+
+      <div id="otherCards" class="grid md:grid-cols-3 gap-4"></div>
     </div>
 
     <script>
@@ -156,20 +179,40 @@
         return num;
       }
 
+      const ICONS = {
+        operaciones:
+          "<path stroke-linecap='round' stroke-linejoin='round' d='M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z' />",
+        ingresos:
+          "<path stroke-linecap='round' stroke-linejoin='round' d='m9 12.75 3 3m0 0 3-3m-3 3v-7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z' />",
+        egresos:
+          "<path stroke-linecap='round' stroke-linejoin='round' d='m15 11.25-3-3m0 0-3 3m3-3v7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z' />",
+        neto:
+          "<path stroke-linecap='round' stroke-linejoin='round' d='M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0 0 12 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 0 1-2.031.352 5.988 5.988 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971Zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 0 1-2.031.352 5.989 5.989 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L5.25 4.971Z' />",
+      };
+
+      function addTopCard(containerId, label, value, icon, color) {
+        const container = document.getElementById(containerId);
+        const card = document.createElement("div");
+        card.className = "bg-white p-4 rounded shadow flex items-center";
+        card.innerHTML =
+          `<svg class='w-8 h-8 ${color} mr-3' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1.5' xmlns='http://www.w3.org/2000/svg'>${icon}</svg>` +
+          `<div><p class='text-sm text-gray-500'>${label}</p><p class='text-lg font-semibold'>${formatNumber(value)}</p></div>`;
+        container.appendChild(card);
+      }
+
       function addCard(containerId, title, obj, labels = {}) {
         const entries = Object.entries(obj || {});
         if (!entries.length) return;
         const container = document.getElementById(containerId);
         const card = document.createElement("div");
-        card.className = "col-md-4 mb-3";
-        let html = `<div class="card h-100"><div class="card-body"><h5 class="card-title">${title}</h5>`;
+        card.className = "bg-white p-4 rounded shadow";
+        let html = `<h5 class="text-lg font-semibold mb-2">${title}</h5>`;
         html += entries
           .map(
             ([k, v]) =>
-              `<p class='card-text'><strong>${labels[k] || k}:</strong> ${formatNumber(v)}</p>`,
+              `<p class='text-sm'><span class='font-medium'>${labels[k] || k}:</span> ${formatNumber(v)}</p>`,
           )
           .join("");
-        html += "</div></div>";
         card.innerHTML = html;
         container.appendChild(card);
       }
@@ -183,52 +226,50 @@
       }
 
       if (data.totals) {
-        addCard("totalsCards", "Totales", data.totals, LABELS.totals);
+        addTopCard(
+          "topCards",
+          "Operaciones",
+          data.totals.n_trx,
+          ICONS.operaciones,
+          "text-blue-500",
+        );
+        addTopCard(
+          "topCards",
+          "Ingresos",
+          data.totals.sum_in,
+          ICONS.ingresos,
+          "text-green-500",
+        );
+        addTopCard(
+          "topCards",
+          "Egresos",
+          data.totals.sum_out,
+          ICONS.egresos,
+          "text-red-500",
+        );
+        addTopCard("topCards", "Neto", data.totals.net, ICONS.neto, "text-gray-500");
 
-        const ctx = document.getElementById("flowChart");
+        const metrics = ["median_abs", "mad_abs", "max_abs", "p95_abs", "p99_abs"];
+        const labels = metrics.map((m) => LABELS.totals[m]);
+        const values = metrics.map((m) => data.totals[m]);
+        const ctx = document.getElementById("amountMetricsChart");
         new Chart(ctx, {
           type: "bar",
           data: {
-            labels: ["Ingresos", "Egresos", "Neto"],
+            labels,
             datasets: [
               {
-                data: [
-                  data.totals.sum_in,
-                  data.totals.sum_out,
-                  data.totals.net,
-                ],
-                backgroundColor: ["#198754", "#dc3545", "#6c757d"],
+                data: values,
+                backgroundColor: "#3b82f6",
               },
             ],
           },
-          options: {
-            plugins: {
-              legend: { display: false },
-              title: { display: true, text: "Flujo" },
-            },
-            scales: { y: { beginAtZero: true } },
-          },
+          options: { scales: { y: { beginAtZero: true } } },
         });
       }
 
       if (data.temporal && data.temporal.hour_hist) {
         const hist = data.temporal.hour_hist;
-        const max = Math.max(...Object.values(hist));
-        const heatmap = document.getElementById("hourHeatmap");
-        for (let h = 0; h < 24; h++) {
-          const val = hist[h] || 0;
-          const intensity = max ? val / max : 0;
-          const div = document.createElement("div");
-          div.style.width = "40px";
-          div.style.height = "40px";
-          div.style.lineHeight = "40px";
-          div.style.textAlign = "center";
-          div.style.border = "1px solid #dee2e6";
-          div.style.backgroundColor = `rgba(13,110,253,${intensity})`;
-          div.innerText = h;
-          heatmap.appendChild(div);
-        }
-
         const hours = Object.keys(hist)
           .map((h) => parseInt(h))
           .sort((a, b) => a - b);
@@ -246,9 +287,7 @@
               },
             ],
           },
-          options: {
-            scales: { y: { beginAtZero: true } },
-          },
+          options: { scales: { y: { beginAtZero: true } } },
         });
       }
 
@@ -261,7 +300,7 @@
             datasets: [
               {
                 data: [val, 100 - val],
-                backgroundColor: ["#dc3545", "#e9ecef"],
+                backgroundColor: ["#ef4444", "#e5e7eb"],
                 borderWidth: 0,
               },
             ],
@@ -278,6 +317,37 @@
           },
         });
       }
+
+      if (data.recency && data.recency.delta_hist) {
+        const hist = data.recency.delta_hist;
+        const bins = Object.keys(hist)
+          .map((b) => parseInt(b))
+          .sort((a, b) => a - b);
+        const counts = bins.map((b) => hist[b]);
+        const recCtx = document.getElementById("recencyHist");
+        new Chart(recCtx, {
+          type: "bar",
+          data: {
+            labels: bins,
+            datasets: [
+              {
+                data: counts,
+                backgroundColor: "#10b981",
+              },
+            ],
+          },
+          options: { scales: { y: { beginAtZero: true } } },
+        });
+        delete data.recency.delta_hist;
+      }
+
+      document
+        .getElementById("outlierInfo")
+        .addEventListener("click", () =>
+          alert(
+            "Porcentaje de montos considerados atípicos usando z-score robusto ≥ 3.5",
+          ),
+        );
 
       if (data.temporal) {
         const temporalData = { ...data.temporal };


### PR DESCRIPTION
## Summary
- Migrar el dashboard a Tailwind con fondo gris.
- Agregar cards superiores con heroicons para operaciones, ingresos, egresos y neto.
- Incluir histogramas y barcharts para outliers, montos y recencia.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abbee17ad083249aa24a3be6269538