### PR TITLE
feat: add raw JSON accordion footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,20 +61,56 @@
         </div>
       </div>
 
-      <div id="otherCards" class="grid md:grid-cols-3 gap-4"></div>
+    <div id="otherCards" class="grid md:grid-cols-3 gap-4"></div>
     </div>
+    <footer class="max-w-5xl mx-auto p-4">
+      <details class="bg-gray-900 text-gray-100 rounded">
+        <summary class="cursor-pointer px-4 py-2 bg-gray-800 text-white rounded">
+          Ver JSON crudo
+        </summary>
+        <pre id="rawJson" class="p-4 overflow-x-auto"></pre>
+      </details>
+    </footer>
 
     <script>
       // Parse JSON from query param 'p'
       let data = {};
+      let rawData = {};
       try {
         const params = new URLSearchParams(window.location.search);
         const p = params.get("p");
         if (p) {
           data = JSON.parse(decodeURIComponent(p));
+          rawData = JSON.parse(JSON.stringify(data));
         }
       } catch (e) {
         console.error("Error parsing data", e);
+      }
+
+      function syntaxHighlight(json) {
+        if (typeof json !== "string") {
+          json = JSON.stringify(json, undefined, 2);
+        }
+        json = json
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+        return json.replace(
+          /("(\u[a-zA-Z0-9]{4}|\[^u]|[^\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,
+          function (match) {
+            let cls = "text-green-300";
+            if (/^"/.test(match)) {
+              cls = /:$/.test(match) ? "text-blue-300" : "text-orange-300";
+            } else if (/true|false/.test(match)) {
+              cls = "text-purple-300";
+            } else if (/null/.test(match)) {
+              cls = "text-pink-300";
+            } else {
+              cls = "text-yellow-300";
+            }
+            return `<span class="${cls}">${match}</span>`;
+          },
+        );
       }
 
       const LABELS = {
@@ -391,6 +427,11 @@
         addCard("otherCards", "Estado", data.status, LABELS.status);
       if (data.duplicates)
         addCard("otherCards", "Duplicados", data.duplicates, LABELS.duplicates);
+
+      const rawPre = document.getElementById("rawJson");
+      if (rawPre) {
+        rawPre.innerHTML = syntaxHighlight(rawData);
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add accordion footer with dark theme to display raw JSON
- highlight JSON syntax for easier inspection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc48f85c483249a73e531928b9a83