### PR TITLE
Fix recency chart memory leak

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,8 +385,10 @@
           }
         };
 
-        const ctx = document.getElementById(canvasId).getContext('2d');
-        if (ctx._chartInstance) ctx._chartInstance.destroy();
+        const canvas = document.getElementById(canvasId);
+        const existing = Chart.getChart(canvas);
+        if (existing) existing.destroy();
+        const ctx = canvas.getContext('2d');
 
         const chart = new Chart(ctx, {
           type: 'scatter',
@@ -449,7 +451,7 @@
           plugins: [dumbbellPlugin]
         });
 
-        ctx._chartInstance = chart;
+        // Chart.js keeps a reference internally, so no manual tracking needed
       }
 
       const LABELS = {


### PR DESCRIPTION
## Summary
- Properly destroy previous Chart.js instance when rendering the recency dumbbell chart to prevent uncontrolled growth and memory leaks.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abcbd41308832492230d000df30f21