### PR TITLE
refactor recency widget to avoid memory leaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,147 +311,105 @@
         return sign + parts.join(' ');
       }
 
+      // Simplified recency widget using raw canvas drawing to avoid Chart.js leaks
       function renderRecencyDumbbell(canvasId, f, { title = "Recencia (P05–P95 con marcadores)" } = {}) {
         const r = (f && f.recency) || {};
-        const p05   = toNum(r.p05_delta_s);
-        const p95   = toNum(r.p95_delta_s);
-        const med   = toNum(r.median_delta_s);
-        const mean  = toNum(r.mean_delta_s);
-
+        const p05  = toNum(r.p05_delta_s);
+        const p95  = toNum(r.p95_delta_s);
+        const med  = toNum(r.median_delta_s);
+        const mean = toNum(r.mean_delta_s);
         const values = [p05, p95, med, mean].filter(v => v != null);
+        if (values.length === 0) return;
+
         const xMin = Math.max(0, Math.min(...values, 0));
         const baseMax = Math.max(...values, 1);
         const xMax = baseMax * 1.1;
 
-        const endpoints = [];
-        if (p05 != null) endpoints.push({ x: p05, y: 0.5, label: "P05" });
-        if (p95 != null) endpoints.push({ x: p95, y: 0.5, label: "P95" });
+        const canvas = document.getElementById(canvasId);
+        if (!canvas) return;
 
-        const markers = [];
-        if (med != null) markers.push({ x: med, y: 0.5, label: "Mediana" });
-        if (mean != null) markers.push({ x: mean, y: 0.5, label: "Media" });
+        const dpr = window.devicePixelRatio || 1;
+        const width = canvas.clientWidth;
+        const height = canvas.clientHeight;
+        canvas.width = width * dpr;
+        canvas.height = height * dpr;
+        const ctx = canvas.getContext('2d');
+        ctx.scale(dpr, dpr);
 
-        const dumbbellPlugin = {
-          id: 'dumbbellPlugin',
-          beforeDatasetsDraw(chart) {
-            const { ctx, chartArea, scales: { x } } = chart;
-            if (!chartArea) return;
-            const y = chartArea.top + chartArea.height * 0.5;
-            const xp05 = Number.isFinite(p05) ? x.getPixelForValue(p05) : null;
-            const xp95 = Number.isFinite(p95) ? x.getPixelForValue(p95) : null;
+        ctx.clearRect(0, 0, width, height);
 
-            ctx.save();
-            if (xp05 != null && xp95 != null) {
-              ctx.lineWidth = 6;
-              ctx.strokeStyle = '#999';
-              ctx.beginPath();
-              ctx.moveTo(Math.min(xp05, xp95), y);
-              ctx.lineTo(Math.max(xp05, xp95), y);
-              ctx.stroke();
-            }
+        // Title
+        ctx.font = '14px system-ui, -apple-system, Segoe UI, Roboto, Arial';
+        ctx.fillStyle = '#111';
+        ctx.textAlign = 'center';
+        ctx.fillText(title, width / 2, 16);
 
-            const drawV = (val, dash=[4,3]) => {
-              if (!Number.isFinite(val)) return;
-              const xv = x.getPixelForValue(val);
-              ctx.setLineDash(dash);
-              ctx.lineWidth = 1;
-              ctx.strokeStyle = '#333';
-              ctx.beginPath();
-              ctx.moveTo(xv, chartArea.top + 6);
-              ctx.lineTo(xv, chartArea.bottom - 6);
-              ctx.stroke();
-              ctx.setLineDash([]);
-            };
-            drawV(med, [6,3]);
-            drawV(mean, [2,2]);
-
-            ctx.restore();
-          },
-          afterDatasetsDraw(chart) {
-            const { ctx, chartArea, scales: { x } } = chart;
-            const labelAbove = (val, text) => {
-              if (!Number.isFinite(val)) return;
-              const xv = x.getPixelForValue(val);
-              ctx.save();
-              ctx.font = '10px system-ui, -apple-system, Segoe UI, Roboto, Arial';
-              ctx.fillStyle = '#111';
-              ctx.textAlign = 'center';
-              ctx.textBaseline = 'bottom';
-              ctx.fillText(text, xv, chartArea.top + 4);
-              ctx.restore();
-            };
-            labelAbove(med, 'Mediana');
-            labelAbove(mean, 'Media');
-          }
+        const chartArea = { left: 40, right: width - 20, top: 30, bottom: height - 30 };
+        const y = (chartArea.top + chartArea.bottom) / 2;
+        const scaleX = (v) => {
+          return chartArea.left + (chartArea.right - chartArea.left) * ((v - xMin) / (xMax - xMin));
         };
 
-        const canvas = document.getElementById(canvasId);
-        const existing = Chart.getChart(canvas);
-        if (existing) existing.destroy();
-        const ctx = canvas.getContext('2d');
+        // Baseline between P05 and P95
+        const xp05 = Number.isFinite(p05) ? scaleX(p05) : null;
+        const xp95 = Number.isFinite(p95) ? scaleX(p95) : null;
+        if (xp05 != null && xp95 != null) {
+          ctx.strokeStyle = '#999';
+          ctx.lineWidth = 6;
+          ctx.beginPath();
+          ctx.moveTo(Math.min(xp05, xp95), y);
+          ctx.lineTo(Math.max(xp05, xp95), y);
+          ctx.stroke();
+          ctx.fillStyle = '#999';
+          ctx.beginPath();
+          ctx.arc(xp05, y, 5, 0, Math.PI * 2);
+          ctx.arc(xp95, y, 5, 0, Math.PI * 2);
+          ctx.fill();
+        }
 
-        const chart = new Chart(ctx, {
-          type: 'scatter',
-          data: {
-            datasets: [
-              {
-                label: 'Extremos',
-                data: endpoints,
-                pointRadius: 5,
-                pointHoverRadius: 6,
-                showLine: false
-              },
-              {
-                label: 'Marcadores',
-                data: markers,
-                pointRadius: 4,
-                pointHoverRadius: 6,
-                showLine: false
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: { display: false },
-              title: { display: true, text: title },
-              tooltip: {
-                callbacks: {
-                  label(ctx) {
-                    const raw = ctx.raw || {};
-                    const name = raw.label || ctx.dataset.label || 'Valor';
-                    const val = ctx.parsed?.x;
-                    return `${name}: ${fmtDuration(val)}`;
-                  },
-                  title() { return ''; }
-                }
-              }
-            },
-            scales: {
-              x: {
-                type: 'linear',
-                suggestedMin: xMin,
-                suggestedMax: xMax,
-                grid: { drawOnChartArea: true },
-                ticks: {
-                  callback: (v) => fmtDuration(v)
-                },
-                title: { display: true, text: 'Δt entre operaciones' }
-              },
-              y: {
-                type: 'linear',
-                min: 0,
-                max: 1,
-                display: false,
-                grid: { display: false }
-              }
-            }
-          },
-          plugins: [dumbbellPlugin]
-        });
+        const drawMarker = (val, dash, label) => {
+          if (!Number.isFinite(val)) return;
+          const xv = scaleX(val);
+          ctx.save();
+          ctx.setLineDash(dash);
+          ctx.strokeStyle = '#333';
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(xv, chartArea.top);
+          ctx.lineTo(xv, chartArea.bottom);
+          ctx.stroke();
+          ctx.restore();
+          ctx.font = '10px system-ui, -apple-system, Segoe UI, Roboto, Arial';
+          ctx.fillStyle = '#111';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'bottom';
+          ctx.fillText(label, xv, chartArea.top - 2);
+        };
 
-        // Chart.js keeps a reference internally, so no manual tracking needed
+        drawMarker(med, [6, 3], 'Mediana');
+        drawMarker(mean, [2, 2], 'Media');
+
+        // X axis
+        ctx.strokeStyle = '#000';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(chartArea.left, chartArea.bottom);
+        ctx.lineTo(chartArea.right, chartArea.bottom);
+        ctx.stroke();
+
+        const tickCount = 4;
+        for (let i = 0; i <= tickCount; i++) {
+          const val = xMin + (xMax - xMin) * (i / tickCount);
+          const xv = scaleX(val);
+          ctx.beginPath();
+          ctx.moveTo(xv, chartArea.bottom);
+          ctx.lineTo(xv, chartArea.bottom + 5);
+          ctx.stroke();
+          ctx.font = '10px system-ui, -apple-system, Segoe UI, Roboto, Arial';
+          ctx.textBaseline = 'top';
+          ctx.textAlign = 'center';
+          ctx.fillText(fmtDuration(val), xv, chartArea.bottom + 7);
+        }
       }
 
       const LABELS = {


### PR DESCRIPTION
## Summary
- rewrite recency dumbbell widget using plain canvas API instead of Chart.js to eliminate memory leak

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abcd7336f48324a93fc5acffe9f76c