### PR TITLE
Reset recency chart before rerendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
       // Parse JSON from query param 'p'
       let data = {};
       let rawData = {};
+      let recencyChart;
       try {
         const params = new URLSearchParams(window.location.search);
         const p = params.get("p");
@@ -210,12 +211,10 @@
           },
         };
 
-        const ctx = document.getElementById(canvasId).getContext("2d");
-        if (ctx._chartInstance) {
-          ctx._chartInstance.destroy();
-        }
+        const ctx = document.getElementById(canvasId);
+        recencyChart?.destroy();
 
-        const chart = new Chart(ctx, {
+        recencyChart = new Chart(ctx, {
           type: "scatter",
           data: {
             datasets: [
@@ -384,12 +383,10 @@
           },
         };
 
-        const ctx = document.getElementById(canvasId).getContext("2d");
-        if (ctx._chartInstance) {
-          ctx._chartInstance.destroy();
-        }
+        const ctx = document.getElementById(canvasId);
+        recencyChart?.destroy();
 
-        const chart = new Chart(ctx, {
+        recencyChart = new Chart(ctx, {
           type: "scatter",
           data: {
             datasets: [
@@ -443,7 +440,6 @@
           },
           plugins: [recencyPlugin],
         });
-        ctx._chartInstance = chart;
       }
 
       const LABELS = {


### PR DESCRIPTION
## Summary
- Declare global `recencyChart` variable
- Destroy previous recency chart instance before drawing a new one
- Ensure rendering assigns the new `Chart` to `recencyChart`

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68abd98614948324ab3d21bd52cfa744