### PR TITLE
Fix undefined chart in robust bullet renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,10 +211,10 @@
           },
         };
 
-        const ctx = document.getElementById(canvasId);
-        recencyChart?.destroy();
+        const canvas = document.getElementById(canvasId);
+        canvas._chartInstance?.destroy();
 
-        recencyChart = new Chart(ctx, {
+        const chart = new Chart(canvas, {
           type: "scatter",
           data: {
             datasets: [
@@ -274,7 +274,7 @@
           plugins: [robustBands],
         });
 
-        ctx._chartInstance = chart;
+        canvas._chartInstance = chart;
       }
 
       function toNum(v) {


### PR DESCRIPTION
## Summary
- fix ReferenceError from robust bullet chart initialization

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abdb57b47c83249a55893eb129e55f