### PR TITLE
Align charts in three columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,9 @@
           <h3 class="text-lg font-semibold mb-2">Histograma horario</h3>
           <canvas id="hourChart" class="bg-white p-2 rounded" height="200"></canvas>
         </div>
-        <div class="space-y-4">
-          <div>
-            <h3 class="text-lg font-semibold mb-2">Ráfagas por ventana</h3>
-            <canvas id="velocityBurstChart" class="bg-white p-2 rounded" height="200"></canvas>
-          </div>
-          <div>
-            <h3 class="text-lg font-semibold mb-2">Frecuencia por tipo</h3>
-            <canvas id="typeFreqDonut" class="bg-white p-2 rounded" height="200"></canvas>
-          </div>
+        <div>
+          <h3 class="text-lg font-semibold mb-2">Ráfagas por ventana</h3>
+          <canvas id="velocityBurstChart" class="bg-white p-2 rounded" height="200"></canvas>
         </div>
       </div>
 
@@ -47,14 +41,18 @@
         ></div>
       </div>
 
-      <div class="grid md:grid-cols-2 gap-4">
+      <div class="grid md:grid-cols-3 gap-4">
+        <div>
+          <h3 class="text-lg font-semibold mb-2">Frecuencia por tipo</h3>
+          <canvas id="typeFreqDonut" class="bg-white p-2 rounded w-full" height="200"></canvas>
+        </div>
         <div>
           <h3 class="text-lg font-semibold mb-2">Rachas 30m OUT vs IN</h3>
-          <canvas id="streaksDivergent" class="bg-white p-2 rounded" height="200"></canvas>
+          <canvas id="streaksDivergent" class="bg-white p-2 rounded w-full" height="200"></canvas>
         </div>
         <div>
           <h3 class="text-lg font-semibold mb-2">Tasa de alternancia</h3>
-          <canvas id="alternationGauge" class="bg-white p-4 rounded" width="200" height="100"></canvas>
+          <canvas id="alternationGauge" class="bg-white p-4 rounded w-full h-48"></canvas>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Place Frecuencia por tipo, Rachas 30m OUT vs IN, and Tasa de alternancia charts in a single three-column grid
- Ensure each chart fills the width of its container for consistent layout

## Testing
- `npm test` *(fails: enoent package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe1370b0c83248ca164a5de40f7ab